### PR TITLE
Fetch token via certificate urls bwc

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -663,13 +663,8 @@ java -Dspring.config.location=file:/path/to/your/myconfig.yaml -jar promregator-
 #### Option "promregator.authenticator.oauth2xsuaa.tokenServiceURL" (mandatory, if using promregator.authenticator.type=OAuth2XSUAA)
 Specifies the URL of the OAuth2 endpoint, which contains the token service of your authorization server in case of global authentication. Typically, this is the endpoint with the path `/oauth/token`, as Promregator will try to perform to establish a ["Client Credentials"-based authentication](https://www.digitalocean.com/community/tutorials/an-introduction-to-oauth-2#grant-type-client-credentials).
 
-#### Option "promregator.authenticator.oauth2xsuaa.xsuaaServiceURL"
-Like `promregator.authenticator.oauth2xsuaa.tokenServiceURL`, but without trailing `/oauth/token`.
-
-If using `promregator.authenticator.type=OAuth2XSUAA` either `promregator.authenticator.oauth2xsuaa.tokenServiceURL` or `promregator.authenticator.oauth2xsuaa.xsuaaServiceURL` must be provided. If both are provided, `promregator.authenticator.oauth2xsuaa.xsuaaServiceURL` takes precedence.
-
-#### Option "promregator.authenticator.oauth2xsuaa.xsuaaServiceCertURL (mandatory for certificate-based authentication, if using promregator.authenticator.type=OAuth2XSUAA)"
-Specifies the URL of the OAuth2 endpoint for certificate based authentication, which contains the token service of your authorization server in case of global authentication. Needs to be provided without a path.
+#### Option "promregator.authenticator.oauth2xsuaa.tokenServiceCertURL (mandatory for certificate-based authentication, if using promregator.authenticator.type=OAuth2XSUAA)"
+Specifies the URL of the OAuth2 endpoint for certificate based authentication, which contains the token service of your authorization server in case of global authentication.
 
 #### Option "promregator.authenticator.oauth2xsuaa.client_id" (mandatory, if using promregator.authenticator.type=OAuth2XSUAA)
 Specifies the client identifier (a.k.a. "client_id") which shall be used during the OAuth2 request based on the Grant Type Client Credentials flow in case of global authentication.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -46,7 +46,7 @@ promregator:
   authenticator:
     type: OAuth2XSUAA
     oauth2xsuaa:
-      xsuaaServiceURL: https://jwt.token.server.example.org
+      tokenServiceURL: https://jwt.token.server.example.org/oauth/token
       client_id: myOAuth2ClientId
 #     client_secret: <should be provided via environment variable PROMREGATOR_AUTHENTICATOR_OAUTH2XSUAA_CLIENT_SECRET>
 
@@ -73,7 +73,7 @@ promregator:
   authenticator:
     type: OAuth2XSUAA
     oauth2xsuaa:
-      xsuaaServiceCertURL: https://jwt.cert.token.server.example.org
+      tokenServiceCertURL: https://jwt.cert.token.server.example.org/oauth/token
       client_id: myOAuth2ClientId
       client_certificates: "-----BEGIN CERTIFICATE-----\nMyIFu...IxZ\n-----END CERTIFICATE-----\n"
 #     client_key: <should be provided via environment variable PROMREGATOR_AUTHENTICATOR_OAUTH2XSUAA_CLIENT_KEY>

--- a/docs/outbound-authentication.md
+++ b/docs/outbound-authentication.md
@@ -70,8 +70,8 @@ basic:
 
 The OAuth2XSUAA Authentication scheme allows to set the following additional configuration options:
 
-* `xsuaaServiceURL` (mandatory for basic authentication): specifies the URL of the OAuth2 server, which shall be used to retrieve the token.
-* `xsuaaServiceCertURL` (mandatory for certificate-based authentication): specifies the URL of the OAuth2 server, which shall be used to retrieve the token.
+* `tokenServiceURL` (mandatory for basic authentication): specifies the URL of the OAuth2 server, which shall be used to retrieve the token.
+* `tokenServiceCertURL` (mandatory for certificate-based authentication): specifies the URL of the OAuth2 server, which shall be used to retrieve the token.
 * `client_id` (mandatory): specifies the client identifier which shall be used when authenticating at the OAuth2 server.
 * `client_secret` (mandatory for basic authentication): specifies the client secret which shall be used when authenticating at the OAuth2 server.
 * `client_certificates` (mandatory for certificate-based authentication): specifies the certificate (chain) which shall be used when authenticating at the OAuth2 server.
@@ -85,7 +85,7 @@ An example of a authentication configuration using basic authentication looks li
 ``` yaml
 type: oauth2xsuaa
 oauth2xsuaa:
-  xsuaaServiceURL: https://instance.subdomain.example.org
+  tokenServiceURL: https://instance.subdomain.example.org/oauth/token
   client_id: myclientid
   client_secret: mysecret
   scopes: scopea,scopeb
@@ -96,7 +96,7 @@ An example of a authentication configuration using certificate-based authenticat
 ``` yaml
 type: oauth2xsuaa
 oauth2xsuaa:
-  xsuaaServiceCertURL: https://instance.subdomain.example.org
+  tokenServiceCertURL: https://instance.subdomain.example.org/oauth/token
   client_id: myclientid
   client_certificates: mycert
   client_key: mykey

--- a/src/main/java/org/cloudfoundry/promregator/auth/NullEndpointProvider.java
+++ b/src/main/java/org/cloudfoundry/promregator/auth/NullEndpointProvider.java
@@ -1,0 +1,40 @@
+package org.cloudfoundry.promregator.auth;
+
+import static com.sap.cloud.security.xsuaa.Assertions.assertNotNull;
+
+import java.net.URI;
+
+import com.sap.cloud.security.config.CredentialType;
+import com.sap.cloud.security.config.OAuth2ServiceConfiguration;
+import com.sap.cloud.security.xsuaa.client.OAuth2ServiceEndpointsProvider;
+
+public class NullEndpointProvider implements OAuth2ServiceEndpointsProvider {
+
+	private final URI baseUri;
+	private final URI certUri;
+
+	public NullEndpointProvider(OAuth2ServiceConfiguration config) {
+		assertNotNull(config, "OAuth2ServiceConfiguration must not be null.");
+		this.baseUri = config.getUrl();
+		if(config.getCredentialType() == CredentialType.X509) {
+			this.certUri = config.getCertUrl();
+		} else {
+			this.certUri = null;
+		}
+	}
+
+	@Override
+	public URI getTokenEndpoint() {
+		return certUri != null ? certUri : baseUri;
+	}
+
+	@Override
+	public URI getAuthorizeEndpoint() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public URI getJwksUri() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/src/main/java/org/cloudfoundry/promregator/auth/OAuth2ServiceConfig.java
+++ b/src/main/java/org/cloudfoundry/promregator/auth/OAuth2ServiceConfig.java
@@ -26,8 +26,8 @@ public class OAuth2ServiceConfig implements OAuth2ServiceConfiguration {
 		properties.put(KEY, config.getClient_key());
 		properties.put(CLIENT_ID, config.getClient_id());
 		properties.put(CLIENT_SECRET, config.getClient_secret());
-		properties.put(URL, config.getXsuaaServiceURL());
-		properties.put(CERT_URL, config.getXsuaaServiceCertURL());
+		properties.put(URL, config.getTokenServiceURL());
+		properties.put(CERT_URL, config.getTokenServiceCertURL());
 	}
 
 	@Override

--- a/src/main/java/org/cloudfoundry/promregator/auth/OAuth2XSUAAEnricher.java
+++ b/src/main/java/org/cloudfoundry/promregator/auth/OAuth2XSUAAEnricher.java
@@ -1,7 +1,5 @@
 package org.cloudfoundry.promregator.auth;
 
-import static java.lang.String.format;
-
 import java.io.Closeable;
 import java.io.IOException;
 
@@ -14,7 +12,6 @@ import org.slf4j.LoggerFactory;
 import com.sap.cloud.security.client.HttpClientFactory;
 import com.sap.cloud.security.config.OAuth2ServiceConfiguration;
 import com.sap.cloud.security.xsuaa.client.DefaultOAuth2TokenService;
-import com.sap.cloud.security.xsuaa.client.XsuaaDefaultEndpoints;
 import com.sap.cloud.security.xsuaa.tokenflows.ClientCredentialsTokenFlow;
 import com.sap.cloud.security.xsuaa.tokenflows.TokenFlowException;
 import com.sap.cloud.security.xsuaa.tokenflows.XsuaaTokenFlows;
@@ -44,7 +41,7 @@ public class OAuth2XSUAAEnricher implements AuthenticationEnricher, Closeable {
 		} else {
 			this.httpClient = HttpClientFactory.create(c.getClientIdentity());
 			this.tokenClient = new XsuaaTokenFlows(new DefaultOAuth2TokenService(this.httpClient),
-					new XsuaaDefaultEndpoints(c), c.getClientIdentity()).clientCredentialsTokenFlow();
+					new NullEndpointProvider(c), c.getClientIdentity()).clientCredentialsTokenFlow();
 		}
 		this.tokenClient.scopes(config.getScopes().toArray(new String[0]));
 
@@ -57,9 +54,7 @@ public class OAuth2XSUAAEnricher implements AuthenticationEnricher, Closeable {
 			} else {
 				log.debug("JWT obtained for client '{}': '{}******'", c.getClientId(), jwt.substring(0, Math.min(10, jwt.length()/3)));
 			}
-		} catch (TokenFlowException e) {
-			log.error(format("Cannot obtain JWT. Did you use deprecated property '%s'? In this case replace it by property '%s'.", OAuth2XSUAAAuthenticationConfiguration.deprecatedTokenServiceURLProperty, OAuth2XSUAAAuthenticationConfiguration.useInsteadXsuaaServiceURLProperty), e);
-		} catch(RuntimeException e) {
+		} catch (TokenFlowException | RuntimeException e) {
 			log.error("Cannot obtain JWT.", e);
 		}
 	}

--- a/src/main/java/org/cloudfoundry/promregator/auth/OAuth2XSUAAEnricher.java
+++ b/src/main/java/org/cloudfoundry/promregator/auth/OAuth2XSUAAEnricher.java
@@ -41,7 +41,7 @@ public class OAuth2XSUAAEnricher implements AuthenticationEnricher, Closeable {
 		} else {
 			this.httpClient = HttpClientFactory.create(c.getClientIdentity());
 			this.tokenClient = new XsuaaTokenFlows(new DefaultOAuth2TokenService(this.httpClient),
-					new NullEndpointProvider(c), c.getClientIdentity()).clientCredentialsTokenFlow();
+					new PromregatorOAuth2ServiceEndpointsProvider(c), c.getClientIdentity()).clientCredentialsTokenFlow();
 		}
 		this.tokenClient.scopes(config.getScopes().toArray(new String[0]));
 

--- a/src/main/java/org/cloudfoundry/promregator/auth/PromregatorOAuth2ServiceEndpointsProvider.java
+++ b/src/main/java/org/cloudfoundry/promregator/auth/PromregatorOAuth2ServiceEndpointsProvider.java
@@ -8,12 +8,12 @@ import com.sap.cloud.security.config.CredentialType;
 import com.sap.cloud.security.config.OAuth2ServiceConfiguration;
 import com.sap.cloud.security.xsuaa.client.OAuth2ServiceEndpointsProvider;
 
-public class NullEndpointProvider implements OAuth2ServiceEndpointsProvider {
+public class PromregatorOAuth2ServiceEndpointsProvider implements OAuth2ServiceEndpointsProvider {
 
 	private final URI baseUri;
 	private final URI certUri;
 
-	public NullEndpointProvider(OAuth2ServiceConfiguration config) {
+	public PromregatorOAuth2ServiceEndpointsProvider(OAuth2ServiceConfiguration config) {
 		assertNotNull(config, "OAuth2ServiceConfiguration must not be null.");
 		this.baseUri = config.getUrl();
 		if(config.getCredentialType() == CredentialType.X509) {

--- a/src/main/java/org/cloudfoundry/promregator/config/OAuth2XSUAAAuthenticationConfiguration.java
+++ b/src/main/java/org/cloudfoundry/promregator/config/OAuth2XSUAAAuthenticationConfiguration.java
@@ -8,7 +8,7 @@ public class OAuth2XSUAAAuthenticationConfiguration {
 
 	private String tokenServiceURL;
 
-	private String tokenServiceCertUrl;
+	private String tokenServiceCertURL;
 
 	private String client_id;
 
@@ -29,11 +29,11 @@ public class OAuth2XSUAAAuthenticationConfiguration {
 	}
 
 	public String getTokenServiceCertURL() {
-		return tokenServiceCertUrl;
+		return tokenServiceCertURL;
 	}
 
 	public void setTokenServiceCertURL(String url) {
-		this.tokenServiceCertUrl = url;
+		this.tokenServiceCertURL = url;
 	}
 
 	public String getClient_id() {

--- a/src/main/java/org/cloudfoundry/promregator/config/OAuth2XSUAAAuthenticationConfiguration.java
+++ b/src/main/java/org/cloudfoundry/promregator/config/OAuth2XSUAAAuthenticationConfiguration.java
@@ -1,27 +1,14 @@
 package org.cloudfoundry.promregator.config;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.http.client.utils.URIBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class OAuth2XSUAAAuthenticationConfiguration {
 
-	public final static String deprecatedTokenServiceURLProperty = "tokenServiceURL";
-	public final static String useInsteadXsuaaServiceURLProperty = "xsuaaServiceURL";
+	private String tokenServiceURL;
 
-	private final static String DEEFAULT_OAUTH_TOKEN_URL_PATH = "/oauth/token";
-
-	private static final Logger log = LoggerFactory.getLogger(OAuth2XSUAAAuthenticationConfiguration.class);
-
-	private String xsuaaServiceURL;
-
-	private String xsuaaServiceCertURL;
+	private String tokenServiceCertUrl;
 
 	private String client_id;
 
@@ -33,39 +20,20 @@ public class OAuth2XSUAAAuthenticationConfiguration {
 
 	private final Set<String> scopes = new HashSet<>();
 
-	public String getXsuaaServiceURL() {
-		return xsuaaServiceURL;
+	public String getTokenServiceURL() {
+		return tokenServiceURL;
 	}
 
 	public void setTokenServiceURL(String url) {
-
-		log.warn("Deprecated property '{}' found. Use '{}' instead without providing trailing '{}'.'", deprecatedTokenServiceURLProperty, useInsteadXsuaaServiceURLProperty, DEEFAULT_OAUTH_TOKEN_URL_PATH);
-		if (getXsuaaServiceURL() != null) {
-			// this does not work always. In case tokenServiceURL is handled first the xsuaaServiceURL is null at this point in time.
-			log.warn("Ignoring deprecated property '{}' ({}) since '{}' ({}) has been provided", deprecatedTokenServiceURLProperty, url, useInsteadXsuaaServiceURLProperty, getXsuaaServiceURL());
-			return;
-		}
-		try {
-			URI u = new URI(url);
-			String rewritten = new URIBuilder().setScheme(u.getScheme()).setHost(u.getHost()).setPort(u.getPort())
-					.setPath(u.getPath().replaceAll(DEEFAULT_OAUTH_TOKEN_URL_PATH + "$", "")).build().toASCIIString();
-			log.warn("Rewriting '{}' ({}) to '{}' in order to use it as '{}'.", deprecatedTokenServiceURLProperty, url, rewritten, useInsteadXsuaaServiceURLProperty);
-			setXsuaaServiceURL(rewritten);
-		} catch (URISyntaxException e) {
-			throw new RuntimeException(e);
-		}
+		this.tokenServiceURL = url;
 	}
 
-	public void setXsuaaServiceURL(String xsuaaServiceURL) {
-		this.xsuaaServiceURL = xsuaaServiceURL;
+	public String getTokenServiceCertURL() {
+		return tokenServiceCertUrl;
 	}
 
-	public String getXsuaaServiceCertURL() {
-		return xsuaaServiceCertURL;
-	}
-
-	public void setXsuaaServiceCertURL(String xsuaaServiceCertURL) {
-		this.xsuaaServiceCertURL = xsuaaServiceCertURL;
+	public void setTokenServiceCertURL(String url) {
+		this.tokenServiceCertUrl = url;
 	}
 
 	public String getClient_id() {

--- a/src/test/java/org/cloudfoundry/promregator/config/OAuth2XSUAAAuthenticationConfigurationTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/config/OAuth2XSUAAAuthenticationConfigurationTest.java
@@ -10,13 +10,6 @@ public class OAuth2XSUAAAuthenticationConfigurationTest {
 
 	@Test
 	public void testTokenServiceURLBackwardCompatibility() {
-
-		/*
-		 * We can still receive an old url containing the path via 'tokenServiceUrl'.
-		 * But the corresponding new property 'url' does not contain the path. The url
-		 * is expected without the path by token-client.
-		 */
-
 		OAuth2XSUAAAuthenticationConfiguration subject = new OAuth2XSUAAAuthenticationConfiguration();
 		subject.setTokenServiceURL("https://example.org/oauth/token");
 		assertThat(subject.getTokenServiceURL(), equalTo("https://example.org/oauth/token"));

--- a/src/test/java/org/cloudfoundry/promregator/config/OAuth2XSUAAAuthenticationConfigurationTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/config/OAuth2XSUAAAuthenticationConfigurationTest.java
@@ -18,30 +18,22 @@ public class OAuth2XSUAAAuthenticationConfigurationTest {
 		 */
 
 		OAuth2XSUAAAuthenticationConfiguration subject = new OAuth2XSUAAAuthenticationConfiguration();
-
 		subject.setTokenServiceURL("https://example.org/oauth/token");
-
-		assertThat(subject.getXsuaaServiceURL(), equalTo("https://example.org"));
+		assertThat(subject.getTokenServiceURL(), equalTo("https://example.org/oauth/token"));
 	}
 
 	@Test
 	public void testTokenServiceURLBackwardCompatibilityWithPrefixInPath() {
-
 		OAuth2XSUAAAuthenticationConfiguration subject = new OAuth2XSUAAAuthenticationConfiguration();
-
 		subject.setTokenServiceURL("https://example.org/v1/oauth/token");
-
-		assertThat(subject.getXsuaaServiceURL(), equalTo("https://example.org/v1"));
+		assertThat(subject.getTokenServiceURL(), equalTo("https://example.org/v1/oauth/token"));
 	}
 
 	@Test
 	public void testTokenServiceURLBackwardCompatibilityWithPort() {
-
 		OAuth2XSUAAAuthenticationConfiguration subject = new OAuth2XSUAAAuthenticationConfiguration();
-
 		subject.setTokenServiceURL("https://example.org:1234/oauth/token");
-
-		assertThat(subject.getXsuaaServiceURL(), equalTo("https://example.org:1234"));
+		assertThat(subject.getTokenServiceURL(), equalTo("https://example.org:1234/oauth/token"));
 	}
 
 	@Test


### PR DESCRIPTION
## Current Situation
In the other PR we have a lot of noise due to url handling

## Problem Statement
We have a lot of noise in the other PR due to url handling

## Solution Approach
We continue with the old approach with regards to URLs
We provide our own url provider. With that we can continue to use urls containing the path suffix `/oauth/token`
Beside this we have a cert url property which fits into the naming scheme (`tokenServerCertURL`).

In order to run that approach we need these config files

basic:

```
cf:
  api_host: [OMITTED]
  username: [OMITTED]

promregator:
  authenticator:
    type: OAuth2XSUAA
    oauth2xsuaa:
      tokenServiceURL: https://[OMITTED]/oauth/token
      client_id: [OMITTED]
#      client_secret: <via environment variable PROMREGATOR_AUTHENTICATOR_OAUTH2XSUAA_CLIENT_SECRET >

  targets:
    - orgName: [OMITTED]
      spaceName: [OMITTED]
      applicationName: [OMITTED]
```

cert:

```
cf:
  api_host: [OMITTED]
  username: [OMITTED]

promregator:
  authenticator:
    type: OAuth2XSUAA
    oauth2xsuaa:
      tokenServiceCertURL: https://[OMITTED].cert.[OMITTED]/oauth/token
      client_id: [OMITTED]
      #client_key:  <via environment variable PROMREGATOR_AUTHENTICATOR_OAUTH2XSUAA_CLIENT_KEY>
      client_certificates: "-----BEGIN CERTIFICATE-----[OMITTED]-----END CERTIFICATE-----\n"

  targets:
    - orgName: [OMITTED]
      spaceName: [OMITTED]
      applicationName: [OMITTED]
```