### PR TITLE
Auth validator

### DIFF
--- a/src/main/java/org/cloudfoundry/promregator/config/validations/AuthenticationConfigurationValidator.java
+++ b/src/main/java/org/cloudfoundry/promregator/config/validations/AuthenticationConfigurationValidator.java
@@ -1,0 +1,106 @@
+package org.cloudfoundry.promregator.config.validations;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.cloudfoundry.promregator.config.AuthenticatorConfiguration;
+import org.cloudfoundry.promregator.config.BasicAuthenticationConfiguration;
+import org.cloudfoundry.promregator.config.OAuth2XSUAABasicAuthenticationConfiguration;
+import org.cloudfoundry.promregator.config.OAuth2XSUAACertificateAuthenticationConfiguration;
+import org.cloudfoundry.promregator.config.PromregatorConfiguration;
+import org.cloudfoundry.promregator.config.TargetAuthenticatorConfiguration;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthenticationConfigurationValidator implements ConfigurationValidation {
+
+	@Override
+	public String validate(PromregatorConfiguration promregatorConfiguration) {
+		List<String> validationFailures = new ArrayList<>();
+		validate(promregatorConfiguration.getAuthenticator(), validationFailures);
+		for (TargetAuthenticatorConfiguration tac : promregatorConfiguration
+				.getTargetAuthenticators()) {
+			validate(tac, validationFailures);
+		}
+		return validationFailures.isEmpty() ? null : StringUtils.join(validationFailures, ", ");
+	}
+
+	private static void validate(AuthenticatorConfiguration authConfig, List<String> validationFailures) {
+		boolean validConfigFound = false;
+		if (authConfig.getBasic() != null && validateBasicAuthConfig(authConfig.getBasic(), validationFailures)) {
+			validConfigFound = true;
+		}
+		if (authConfig.getOauth2xsuaa() != null && validateOauth2xsuaaBasic(authConfig.getOauth2xsuaa(), validationFailures)) {
+			validConfigFound = true;
+		}
+		if (authConfig.getOauth2xsuaaBasic() != null && validateOauth2xsuaaBasic(authConfig.getOauth2xsuaaBasic(), validationFailures)) {
+			validConfigFound = true;
+		}
+		if (authConfig.getOauth2xsuaaCertificate() != null && validateOauth2xsuaaCertificate(authConfig.getOauth2xsuaaCertificate(), validationFailures)) {
+			validConfigFound = true;
+		}
+		if (validConfigFound) {
+			validationFailures.clear();
+		}
+	}
+
+	private static boolean validateBasicAuthConfig(BasicAuthenticationConfiguration config,
+			List<String> validationFailures) {
+		boolean isValid = true;
+		if (isBlank(config.getUsername())) {
+			isValid = false;
+			validationFailures.add(String.format("%s without username found", config.getClass().getSimpleName()));
+		}
+		if (isBlank(config.getPassword())) {
+			isValid = false;
+			validationFailures.add(String.format("%s without password found", config.getClass().getSimpleName()));
+		}
+		return isValid;
+	}
+
+	private static boolean validateOauth2xsuaaBasic(OAuth2XSUAABasicAuthenticationConfiguration config,
+			List<String> validationFailures) {
+		boolean isValid = true;
+		if (isBlank(config.getClient_id())) {
+			isValid = false;
+			validationFailures.add(String.format("%s without client id found", config.getClass().getSimpleName()));
+		}
+		if (isBlank(config.getClient_secret())) {
+			isValid = false;
+			validationFailures.add(String.format("%s without client secret found", config.getClass().getSimpleName()));
+		}
+		if (isBlank(config.getTokenServiceURL())) {
+			isValid = false;
+			validationFailures
+					.add(String.format("%s without token service url found", config.getClass().getSimpleName()));
+		}
+		return isValid;
+	}
+
+	private static boolean validateOauth2xsuaaCertificate(OAuth2XSUAACertificateAuthenticationConfiguration config,
+			List<String> validationFailures) {
+		boolean isValid = true;
+		if (isBlank(config.getClient_id())) {
+			isValid = false;
+			validationFailures
+					.add(String.format("%s auth config without client id found", config.getClass().getSimpleName()));
+		}
+		if (isBlank(config.getClient_certificates())) {
+			isValid = false;
+			validationFailures
+					.add(String.format("%s without client certificate found", config.getClass().getSimpleName()));
+		}
+		if (isBlank(config.getClient_key())) {
+			validationFailures.add(String.format("%s without client key found", config.getClass().getSimpleName()));
+		}
+		if (isBlank(config.getTokenServiceCertURL())) {
+			isValid = false;
+			validationFailures.add(
+					String.format("%s without token service certificate URL found", config.getClass().getSimpleName()));
+		}
+		return isValid;
+	}
+}


### PR DESCRIPTION
## Current Situation

Authentication config is not validated

## Problem Statement

Authentication config is not validated

## Solution Approach

We provide a validator for the auth config

## Why we might not use this PR

The validators are current executed after the initialisation of the enricher.

When not applying any changes to the `token-client`-setup we fail  in case of an invalid config when setting up the `token-client` and not by the validator 😕 . We might think of the initialisation of the token client as some kind of real-world valiation 😄 .

In order to "fix" the failure while setting up the "token-client" we catch the exception there. The token client is also not final anymore and it can be `null`. Without that we would never reach the validator.

I don't know if it is possible to execute the validator(s) at an earlier point in time (... or the setup of the enrichers later).

In case we cannot control the order (... validators first) I personally would drop the validator since the `token-client` performs a validation and the exception is specific enough for troubleshooting. Even in case we can ensure the validators are executed first I would most likely not add an own validator. At least not for the xsuaa related auth config parts.